### PR TITLE
Update umemoria.cls

### DIFF
--- a/umemoria.cls
+++ b/umemoria.cls
@@ -41,7 +41,7 @@
 
 %% Lenguaje
 \addto\captionsspanish{\renewcommand\tablename{Tabla}}
-\addto\captionsspanish{\renewcommand\contentsname{Tabla de Contenidos}}
+\addto\captionsspanish{\renewcommand\contentsname{Tabla de Contenido}}
 \addto\captionsspanish{\renewcommand\listtablename{Índice de Tablas}}
 \addto\captionsspanish{\renewcommand\listfigurename{Índice de Ilustraciones}}
 


### PR DESCRIPTION
La pauta de tesis disponible en u-campus, página 4, establece que el titulo del índice debe ser "Tabla de contenido" sin "s".